### PR TITLE
Add column headings to my tasks

### DIFF
--- a/src/components/Content/MyTasks/MyTasks.css
+++ b/src/components/Content/MyTasks/MyTasks.css
@@ -1,5 +1,32 @@
 @media (max-width: 899px) {
-  .synthetic-tasklist .hide-small {
+  .synthetic-tasklist .hide-small, 
+  #my-task-label-reassign.hide-small, 
+  #my-task-label-due-date.hide-small  {
     display: none;
   }
+
+}
+
+#my-task-labels {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  max-width: 92%;
+  padding: 0px 0px 3px 80px;
+  color: #eaeaea;
+  font-size: 1.36em;
+  text-decoration: underline;
+}
+
+#my-task-label-title {
+  justify-self: flex-start;
+  flex: 1;
+}
+
+#my-task-label-reassign {
+  width: 185px;
+}
+
+#my-task-label-due-date {
+  width: 108px;
 }

--- a/src/components/Content/MyTasks/MyTasks.css
+++ b/src/components/Content/MyTasks/MyTasks.css
@@ -8,19 +8,19 @@
 }
 
 #my-task-labels {
+  color: #eaeaea;
   display: flex;
   flex-direction: row;
+  font-size: 1.36em;
   justify-content: flex-end;
   max-width: 92%;
   padding: 0px 0px 3px 80px;
-  color: #eaeaea;
-  font-size: 1.36em;
   text-decoration: underline;
 }
 
 #my-task-label-title {
-  justify-self: flex-start;
   flex: 1;
+  justify-self: flex-start;
 }
 
 #my-task-label-reassign {

--- a/src/components/Content/MyTasks/MyTasks.js
+++ b/src/components/Content/MyTasks/MyTasks.js
@@ -117,6 +117,23 @@ class MyTasks extends Component {
             <Tab eventKey={0} title="Unified" className="invite-hierarchy">
               <div>
                 <h3>Unified Task List</h3>
+                <div id="my-task-labels">
+                 <div id="my-task-label-title">
+                   <span>
+                      Task Title
+                   </span>
+                 </div>
+                 <div id="my-task-label-reassign" className="hide-small">
+                   <span>
+                    Reassign
+                   </span>
+                 </div>
+                 <div id="my-task-label-due-date" className="hide-small">
+                   <span>
+                      Due Date
+                   </span>
+                 </div>
+                </div>
                 <SyntheticTaskList
                   taskGids={taskGids}
                 />


### PR DESCRIPTION
Fix to resolve issue #31.  Added some column headings for the My Tasks list of tasks.  Styled them with flexbox and some fixed width titles so they follow the content responsively.  They are set to hide at the same time the content hides.  